### PR TITLE
Fixing rubocop offenses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './lib/version'
 require 'bundler/gem_tasks'
 

--- a/lib/rtoolsHCK.rb
+++ b/lib/rtoolsHCK.rb
@@ -425,10 +425,10 @@ class RToolsHCK
     action_parameters = method(action).parameters.map do |param|
       param_str = "#{param[1]} "
       param_str + if param[0].equal?(:opt)
-                     "is #{binding.local_variable_get(param[1]) ? 'on' : 'off'}"
-                   else
-                     "= #{binding.local_variable_get(param[1])}"
-                   end
+                    "is #{binding.local_variable_get(param[1]) ? 'on' : 'off'}"
+                  else
+                    "= #{binding.local_variable_get(param[1])}"
+                  end
     end
     logger('debug', "action/#{action}") { action_parameters.join(', ') }
   end

--- a/rtoolsHCK.gemspec
+++ b/rtoolsHCK.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require './lib/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Causes:
 1. Changes in commit bc49e737fc2890d7980ac989af4fb008344111f2,
    (lib/rtoolsHCK)
 2. New version of rubocop 0.69
    (rtoolsHCK.gemspec, Rakefile)

Signed-off-by: Bishara AbuHattoum <bishara@daynix.com>