### PR TITLE
Deprecating the usage of Telnet protocol and using TCPSocket instead

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,5 +3,5 @@
 # rtoolsHCK version extend to class
 class RToolsHCK
   # Current rtoolsHCK version
-  VERSION = '0.2.14'
+  VERSION = '0.2.15'
 end


### PR DESCRIPTION
Telnet protocol was used in order to forward the toolsHCK.ps1 script
functionality by opening an interactive shell, but since Microsoft
declared Telnet functionality deprecated on Windows Server 2016 and
higher, we also need to deprecate the usage of Telnet protocol.

This commit holds the complete patch to convert the usage of Telnet
to using TCPSocket and toolsHCK.ps1 in server mode without sacrificing
any of the functionalities that RToolsHCK provides.

NOTE: toolsHCK.ps1 should be up to date!