### PR TITLE
rtoolsHCK: Shutdown without time-out period

### DIFF
--- a/lib/rtoolsHCK.rb
+++ b/lib/rtoolsHCK.rb
@@ -1056,7 +1056,7 @@ class RToolsHCK
   #                  default
   def shutdown(restart: false)
     handle_action_exceptions(__method__) do
-      cmd_line = ['shutdown -f -t 00']
+      cmd_line = ['shutdown -f -t 00 -p']
       cmd_line << (restart ? '-r' : '-s')
 
       run(cmd_line.join(' '))
@@ -1076,7 +1076,7 @@ class RToolsHCK
   #                  default
   def machine_shutdown(machine, restart: false)
     handle_action_exceptions(__method__) do
-      cmd_line = ['shutdown -f -t 00']
+      cmd_line = ['shutdown -f -t 00 -p']
       cmd_line << (restart ? '-r' : '-s')
 
       machine_run(machine, cmd_line.join(' '))


### PR DESCRIPTION
shutdown command has time-out period by default. While it is good for
normal situations, it does not make sense for automated tests.

-p option can avoid time-out period.
https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/shutdown
> Turns off the local computer only (not a remote computer)—with no
time-out period or warning. You can use /p only with /d or /f. If your
> computer doesn't support power-off functionality, it will shut down
> when you use /p, but the power to the computer will remain on.

Signed-off-by: Akihiko Odaki <akihiko.odaki@gmail.com>