### PR TITLE
Bump rtoolsHCK version (0.4.0)

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,5 +3,5 @@
 # rtoolsHCK version extend to class
 class RToolsHCK
   # Current rtoolsHCK version
-  VERSION = '0.3.4'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
Bump minor as we bump minimal ruby version.