### PR TITLE
Capture server exception as an action exception

### DIFF
--- a/lib/rtoolsHCK.rb
+++ b/lib/rtoolsHCK.rb
@@ -388,7 +388,7 @@ class RToolsHCK
     log_action_call(action, block.binding)
     handle_exceptions do
       yield
-    rescue RToolsHCKActionError => e
+    rescue RToolsHCKError => e
       action_exception_handler(e)
     end
   end


### PR DESCRIPTION
This allows to reptry command when the server exited unexpectedly. For example, in case the WinRM connection is broken.