### PR TITLE
Bump rtoolsHCK version (0.7.0)

### DIFF
--- a/lib/version.rb
+++ b/lib/version.rb
@@ -3,5 +3,5 @@
 # rtoolsHCK version extend to class
 class RToolsHCK
   # Current rtoolsHCK version
-  VERSION = '0.6.4'
+  VERSION = '0.7.0'
 end

--- a/tools/toolsHCK.ps1
+++ b/tools/toolsHCK.ps1
@@ -40,7 +40,7 @@ if ($env:WTTSTDIO -like "*\Hardware Certification Kit\*") {
 }
 
 ##
-$Version = "0.6.4"
+$Version = "0.7.0"
 $MaxJsonDepth = 6
 ##
 


### PR DESCRIPTION
Bump minor due to API changes and backward compatibility breaks.