### PR TITLE
toolsHCK: remove UnloadPlaylist call

### DIFF
--- a/tools/toolsHCK.ps1
+++ b/tools/toolsHCK.ps1
@@ -2279,16 +2279,6 @@ function createprojectpackage {
     $PackageWriter.Save($PackagePath)
     $PackageWriter.Dispose()
 
-    if ($PlaylistManager) {
-        if (-Not $json) {
-            Write-Output "Unloading playlist"
-        } else {
-            $actionMessages += "Unloading playlist"
-        }
-
-        $PlaylistManager.UnloadPlaylist()
-    }
-
     if (-Not $json) {
         Write-Output "Packaged to $($PackagePath)..."
     } else {


### PR DESCRIPTION
Remove the UnloadPlaylist call as only one playlist is loaded per run, making it unnecessary.